### PR TITLE
Fixes for cards that apply during the Battle Phase and cards that send to opponent's Graveyard

### DIFF
--- a/scripts/c100000088.lua
+++ b/scripts/c100000088.lua
@@ -1,0 +1,42 @@
+--バトル・リターン
+function c100000088.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c100000088.condition)
+	e1:SetTarget(c100000088.target)
+	e1:SetOperation(c100000088.activate)
+	c:RegisterEffect(e1)
+end
+function c100000088.condition(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return Duel.GetTurnPlayer()==tp and ph>=0x08 and ph<=0x20 and (ph~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
+end
+function c100000088.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x3013)
+end
+function c100000088.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingTarget(c100000088.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c100000088.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c100000088.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EXTRA_ATTACK)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(1)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+RESET_END)
+		e2:SetValue(tc:GetAttack()/2)
+		tc:RegisterEffect(e2)
+	end
+end

--- a/scripts/c100000110.lua
+++ b/scripts/c100000110.lua
@@ -8,16 +8,6 @@ function c100000110.initial_effect(c)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetValue(aux.FALSE)
 	c:RegisterEffect(e1)
-	--spsummon proc
-	local e2=Effect.CreateEffect(c)	
-	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_PHASE+PHASE_END)
-	e2:SetCountLimit(1)
-	e2:SetRange(0xFF)
-	e2:SetTargetRange(LOCATION_MZONE,0)
-	e2:SetOperation(c100000110.spop)
-	c:RegisterEffect(e2)
 	--special summon
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD)
@@ -42,14 +32,24 @@ function c100000110.initial_effect(c)
 	e7:SetCode(EFFECT_IMMUNE_EFFECT)
 	e7:SetValue(c100000110.efilter)
 	c:RegisterEffect(e7)
+	if not c100000110.global_check then
+		c100000110.global_check=true
+		--spsummon proc
+		local e2=Effect.CreateEffect(c)	
+		e2:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_PHASE+PHASE_END)
+		e2:SetCountLimit(1)
+		e2:SetOperation(c100000110.spop)
+		Duel.RegisterEffect(e2,0)
+	end
 end
 function c100000110.spfilter1(c)
 	return c:IsFaceup() and c:GetLevel()==1 and c:IsType(TYPE_NORMAL)
 end
 function c100000110.spop(e,tp,c)
 	local c=e:GetHandler()
-	if c:GetControler()~=Duel.GetTurnPlayer() then return end
-	local g=Duel.GetMatchingGroup(c100000110.spfilter1,c:GetControler(),LOCATION_MZONE,0,nil)
+	local g=Duel.GetMatchingGroup(c100000110.spfilter1,Duel.GetTurnPlayer(),LOCATION_MZONE,0,nil)
 	local rc=g:GetFirst()
 	while rc do
 		if rc:GetFlagEffect(100000110)==0 then 
@@ -59,7 +59,6 @@ function c100000110.spop(e,tp,c)
 			e1:SetCode(EVENT_PHASE_START+PHASE_STANDBY)
 			e1:SetCountLimit(1)
 			e1:SetRange(LOCATION_MZONE)
-			e1:SetTargetRange(LOCATION_MZONE,0)
 			e1:SetCondition(c100000110.spcon1)
 			e1:SetLabel(0)
 			e1:SetOperation(c100000110.spop2)

--- a/scripts/c100000218.lua
+++ b/scripts/c100000218.lua
@@ -1,0 +1,52 @@
+--爆風紋章
+function c100000218.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c100000218.eqcon)
+	e1:SetTarget(c100000218.target)
+	e1:SetOperation(c100000218.activate)
+	c:RegisterEffect(e1)
+end
+function c100000218.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
+end
+function c100000218.filter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToHand()
+end
+function c100000218.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return Duel.IsExistingMatchingCard(c100000218.filter,tp,0,LOCATION_ONFIELD,1,nil) end
+	local sg=Duel.GetMatchingGroup(c100000218.filter,tp,0,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,sg,sg:GetCount(),0,0)
+end
+function c100000218.activate(e,tp,eg,ep,ev,re,r,rp)
+	local sg=Duel.GetMatchingGroup(c100000218.filter,tp,0,LOCATION_ONFIELD,nil)
+	Duel.SendtoHand(sg,nil,REASON_EFFECT)	
+	Duel.BreakEffect()
+	Duel.SkipPhase(Duel.GetTurnPlayer(),PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	--damage
+	local e1=Effect.CreateEffect(e:GetHandler())	
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetLabel(sg:GetCount())
+	e1:SetTarget(c100000218.datarget)
+	e1:SetOperation(c100000218.operation)
+	Duel.RegisterEffect(e1,tp)
+end
+function c100000218.datarget(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local dam=e:GetLabel()*500
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+end
+function c100000218.operation(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/scripts/c511000621.lua
+++ b/scripts/c511000621.lua
@@ -37,15 +37,15 @@ function c511000621.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO)
 end
 function c511000621.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
-	if chk==0 then return Duel.IsExistingTarget(c511000621.filter,tp,LOCATION_MZONE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c511000621.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if c:IsRelateToEffect(e) and tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -61,7 +61,7 @@ function c511000621.val(e,c)
 	return g:GetSum(Card.GetBaseAttack)
 end
 function c511000621.con(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE and not e:GetHandler():IsStatus(STATUS_CHAINING)
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE and not e:GetHandler():IsStatus(STATUS_CHAINING)
 end
 function c511000621.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsDestructable() end

--- a/scripts/c511000948.lua
+++ b/scripts/c511000948.lua
@@ -33,7 +33,8 @@ end
 function c511000948.damcon(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()
 	e:SetLabelObject(re)
-	return eg:IsExists(c511000948.cfilter,1,nil,re) and (ph==PHASE_BATTLE or (ph==PHASE_DAMAGE and not Duel.IsDamageCalculated()))
+	return eg:IsExists(c511000948.cfilter,1,nil,re) and 
+		((Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE) or (ph==PHASE_DAMAGE and not Duel.IsDamageCalculated()))
 end
 function c511000948.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/scripts/c511000975.lua
+++ b/scripts/c511000975.lua
@@ -11,7 +11,7 @@ function c511000975.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511000975.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511000975.filter(c)
 	return c:GetTurnID()==Duel.GetTurnCount() and bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)~=0

--- a/scripts/c511001056.lua
+++ b/scripts/c511001056.lua
@@ -13,25 +13,10 @@ function c511001056.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGrave,tp,LOCATION_DECK,0,1,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 end
-function c511001056.filter(c,tp)
-	return c:GetOwner()==tp
-end
 function c511001056.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGrave,tp,LOCATION_DECK,0,1,1,nil)
 	if g:GetCount()>0 then
-		local g1=Duel.GetFieldGroup(tp,0,LOCATION_DECK)
-		local g2=Duel.GetFieldGroup(tp,0,LOCATION_GRAVE)
-		local g3=Duel.GetMatchingGroup(c511001056.filter,tp,0,LOCATION_GRAVE,nil,tp)
-		if g3:GetCount()>0 then
-			Duel.SwapDeckAndGrave(1-tp)
-			Duel.SwapDeckAndGrave(1-tp)
-		end
-		g:Merge(g3)
-		Duel.SendtoDeck(g,1-tp,0,REASON_RULE)
-		Duel.SwapDeckAndGrave(1-tp)
-		Duel.SendtoDeck(g1,1-tp,0,REASON_RULE)
-		Duel.SendtoGrave(g2,REASON_RULE+REASON_RETURN)
-		Duel.SendtoGrave(g2,REASON_RULE+REASON_RETURN)
+		Duel.SendtoGrave(g,REASON_EFFECT,1-tp)
 	end
 end

--- a/scripts/c511001132.lua
+++ b/scripts/c511001132.lua
@@ -57,7 +57,8 @@ function c511001132.condition(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer()
 end
 function c511001132.descon(e,tp,eg,ep,ev,re,r,rp)
-	return c511001132[4]>0 and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 and Duel.GetCurrentPhase()==PHASE_BATTLE
+	return c511001132[4]>0 and Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 
+		and Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511001132.checkop(e,tp,eg,ep,ev,re,r,rp)
     c511001132[0]=c511001132[0]+Duel.GetLP(tp)

--- a/scripts/c511001242.lua
+++ b/scripts/c511001242.lua
@@ -11,8 +11,7 @@ function c511001242.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511001242.condition(e,tp,eg,ep,ev,re,r,rp)
-	local ph=Duel.GetCurrentPhase()
-	return ph==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511001242.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:GetLocation()==LOCATION_HAND and chkc:GetControler()==tp and chkc:IsAbleToHand() end

--- a/scripts/c511001341.lua
+++ b/scripts/c511001341.lua
@@ -42,8 +42,8 @@ function c511001341.clear(e,tp,eg,ep,ev,re,r,rp)
 	c511001341[0]:Clear()
 end
 function c511001341.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
-		and (Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
+	local ph=Duel.GetCurrentPhase()
+	return ph>=0x08 and ph<=0x20and (ph~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
 end
 function c511001341.filter(c,e,tp)
 	return c:IsCanBeEffectTarget(e) and c:IsFaceup() and c:IsControler(tp)

--- a/scripts/c511001654.lua
+++ b/scripts/c511001654.lua
@@ -12,7 +12,7 @@ function c511001654.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511001654.sccon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511001654.spfilter(c,e,tp)
 	return c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,true,false) 

--- a/scripts/c511001801.lua
+++ b/scripts/c511001801.lua
@@ -11,7 +11,7 @@ function c511001801.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511001801.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511001801.filter(c,e)
 	return c:IsDestructable() and (not e or c:IsRelateToEffect(e))

--- a/scripts/c511002139.lua
+++ b/scripts/c511002139.lua
@@ -11,8 +11,7 @@ function c511002139.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511002139.condition(e,tp,eg,ep,ev,re,r,rp)
-	local ph=Duel.GetCurrentPhase()
-	return ph>=0x08 and ph<=0x20
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511002139.filter(c,tp)
 	return c:IsFaceup() and c:IsControler(1-tp) and c:IsOnField() and c:IsDestructable()

--- a/scripts/c511002369.lua
+++ b/scripts/c511002369.lua
@@ -11,8 +11,7 @@ function c511002369.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511002369.condition(e,tp,eg,ep,ev,re,r,rp)
-	local ph=Duel.GetCurrentPhase()
-	return ph==PHASE_BATTLE or (ph==PHASE_DAMAGE and not Duel.IsDamageCalculated())
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511002369.tfilter(c,att,e,tp)
 	return c:IsSetCard(0xa008) and c:GetLevel()==8 and c:IsAttribute(att) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)

--- a/scripts/c511002464.lua
+++ b/scripts/c511002464.lua
@@ -38,7 +38,7 @@ function c511002464.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function c511002464.con1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511002464.cost1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end

--- a/scripts/c511002637.lua
+++ b/scripts/c511002637.lua
@@ -13,7 +13,8 @@ function c511002637.cfilter(c)
 	return c:IsSetCard(0x21a) or c:IsCode(82382815)
 end
 function c511002637.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE and Duel.IsExistingMatchingCard(c511002637.cfilter,tp,LOCATION_GRAVE,0,2,nil)
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE 
+		and Duel.IsExistingMatchingCard(c511002637.cfilter,tp,LOCATION_GRAVE,0,2,nil)
 end
 function c511002637.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end

--- a/scripts/c511002706.lua
+++ b/scripts/c511002706.lua
@@ -71,7 +71,7 @@ function c511002706.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c511002706.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetFlagEffect(511002706)>0 
-		and Duel.GetCurrentPhase()==PHASE_BATTLE
+		and Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511002706.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not e:GetHandler():IsStatus(STATUS_CHAINING) 

--- a/scripts/c511002735.lua
+++ b/scripts/c511002735.lua
@@ -11,7 +11,7 @@ function c511002735.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511002735.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511002735.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetMatchingGroupCount(Card.IsAbleToRemove,tp,0,LOCATION_MZONE,nil)

--- a/scripts/c511002868.lua
+++ b/scripts/c511002868.lua
@@ -15,7 +15,7 @@ function c511002868.cfilter(c)
 	return bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
 end
 function c511002868.xyzcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE 
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE  
 		and Duel.IsExistingMatchingCard(c511002868.cfilter,tp,0,LOCATION_MZONE,1,nil)
 end
 function c511002868.xyzfilter(c)

--- a/scripts/c511002899.lua
+++ b/scripts/c511002899.lua
@@ -12,7 +12,7 @@ function c511002899.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511002899.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
 end
 function c511002899.filter(c,e,tp,tid)
 	return bit.band(c:GetReason(),REASON_BATTLE)~=0 and c:GetTurnID()==tid and c:IsCanBeSpecialSummoned(e,0,tp,false,false) 

--- a/scripts/c511002957.lua
+++ b/scripts/c511002957.lua
@@ -11,7 +11,7 @@ function c511002957.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511002957.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()==PHASE_BATTLE and not e:GetHandler():IsStatus(STATUS_CHAINING) 
+	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE and not e:GetHandler():IsStatus(STATUS_CHAINING) 
 		and Duel.GetTurnCount()==e:GetHandler():GetTurnID() and not e:GetHandler():IsReason(REASON_RETURN)
 end
 function c511002957.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/scripts/c810000002.lua
+++ b/scripts/c810000002.lua
@@ -32,9 +32,6 @@ function c810000002.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
 	Duel.SelectTarget(tp,c810000002.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,nil,e,tp)
 end
-function c810000002.filterx(c,tp)
-	return c:GetOwner()==tp
-end
 function c810000002.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) and (tc:IsType(TYPE_FIELD) or Duel.GetLocationCount(tp,LOCATION_SZONE)>0) then
@@ -76,22 +73,6 @@ function c810000002.activate(e,tp,eg,ep,ev,re,r,rp)
 				etc=g:GetNext()
 			end
 		end
-		if p~=tp then
-			Duel.SendtoGrave(tc,REASON_RULE)
-		else
-			local g1=Duel.GetFieldGroup(tp,0,LOCATION_DECK)
-			local g2=Duel.GetFieldGroup(tp,0,LOCATION_GRAVE)
-			local g3=Duel.GetMatchingGroup(c810000002.filterx,tp,0,LOCATION_GRAVE,nil,tp)
-			if g3:GetCount()>0 then
-				Duel.SwapDeckAndGrave(1-tp)
-				Duel.SwapDeckAndGrave(1-tp)
-			end
-			g3:AddCard(tc)
-			Duel.SendtoDeck(g3,1-tp,0,REASON_RULE)
-			Duel.SwapDeckAndGrave(1-tp)
-			Duel.SendtoDeck(g1,1-tp,0,REASON_RULE)
-			Duel.SendtoGrave(g2,REASON_RULE+REASON_RETURN)
-			Duel.SendtoGrave(g2,REASON_RULE+REASON_RETURN)
-		end
+		Duel.SendtoGrave(tc,REASON_EFFECT,1-tp)
 	end
 end


### PR DESCRIPTION
Cards that send to Opponent's Graveyard include Foolish Burial and Dark Spell Regeneration

Zushin script format fixed.