### PR TITLE
Gearspring Catapult fix

### DIFF
--- a/scripts/c511009016.lua
+++ b/scripts/c511009016.lua
@@ -9,7 +9,7 @@ function c511009016.initial_effect(c)
 	
 	--counter
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD++EFFECT_TYPE_CONTINUOUS)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCountLimit(1)


### PR DESCRIPTION
removed a wild "+" that should not have been here